### PR TITLE
Fixing typo and also changing example branch name in README

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,7 +33,7 @@ Here are some notes on how you can get the VespAI detection running using the pr
     - `<rpi-host>` is the hostname or IP address of your Raspberry Pi.
     - `<username>` is the name of the primary user you setup on your Raspberry Pi.
     - `<git-repo-url>` is the URL of the git repo, e.g. `https://github.com/andrw3000/vespai.git`
-    - `<git-repo-branch` is the branch-name (or other git ref) in the git repo, e.g. `ansible-deployment`
+    - `<git-repo-branch>` is the branch-name (or other git ref) in the git repo, e.g. `main`
 
 > [!NOTE]
 > This playbook clones the vespai repository and tracks/updates all submodules (to mitigate [issue #1](https://github.com/andrw3000/vespai/issues/1)); it subsequently checks out the `models/yolov5` submodule to [commit `23701eac`](https://github.com/ultralytics/yolov5/tree/23701eac7a7b160e478ba4bbef966d0af9348251), which was at the [HEAD of main branch](https://github.com/andrw3000/vespai/tree/786c394a8835cc2850ec3a462a8aaaf2e8520172/models) when I first created this playbook. _Using the older commit/version of `yolov5` stops it automatically trying to download newer package versions/dependencies; also, `monitor/monitor_run.py` throws a `ModuleNotFoundError` exception when run with the current HEAD of `yolov5` main branch._


### PR DESCRIPTION
Fixing typo and also changing example branch name, now that original PR was merged to 'main', ref. #5.